### PR TITLE
review Dockerfile: better buildtime caching, use debian:bookworm; add .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+**
+!entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,45 +1,68 @@
-FROM debian:bullseye-slim AS builder
-
 ARG OCSERV_VERSION=1.3.0
-ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends \
+FROM debian:bookworm-slim AS base
+ENV DEBIAN_FRONTEND=noninteractive
+RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
+
+FROM base AS builder
+ARG OCSERV_VERSION
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    --mount=type=tmpfs,target=/var/log \
+    --mount=type=tmpfs,target=/var/tmp \
+    --mount=type=tmpfs,target=/var/cache/debconf \
+    --mount=type=tmpfs,target=/run \
+    --mount=type=tmpfs,target=/tmp \
+    set -x \
+ && apt-get update \
+ && apt-get upgrade -y -qq \
+ && apt-get install -y --no-install-recommends --no-install-suggests \
     build-essential pkg-config wget ca-certificates \
     libgnutls28-dev libev-dev libreadline-dev libpam0g-dev liblz4-dev \
     libseccomp-dev libnl-route-3-dev libkrb5-dev libradcli-dev \
     libcurl4-gnutls-dev libcjose-dev libjansson-dev liboath-dev \
-    libprotobuf-c-dev libtalloc-dev libhttp-parser-dev protobuf-c-compiler gperf ipcalc-ng && \
-    rm -rf /var/lib/apt/lists/*
+    libprotobuf-c-dev libtalloc-dev libhttp-parser-dev protobuf-c-compiler gperf ipcalc-ng gpg gpg-agent
 
 WORKDIR /tmp
 
-RUN mkdir -p /opt/ocserv && \
-    wget ftp://ftp.infradead.org/pub/ocserv/ocserv-${OCSERV_VERSION}.tar.xz && \
+RUN --mount=type=tmpfs,target=/tmp \
+    set -x && \
+    mkdir -p /opt/ocserv && \
+    wget https://ocserv.openconnect-vpn.net/assets/keys/96865171.asc && \
+    wget https://www.infradead.org/ocserv/download/ocserv-${OCSERV_VERSION}.tar.xz && \
+    wget https://www.infradead.org/ocserv/download/ocserv-${OCSERV_VERSION}.tar.xz.sig && \
+    gpg --no-default-keyring --keyring ${PWD}/keyring.gpg --import 96865171.asc && \
+    gpg -v --status-fd 1 --no-default-keyring --keyring ${PWD}/keyring.gpg --verify ocserv-${OCSERV_VERSION}.tar.xz.sig 2>&1 | grep "VALIDSIG" && \
     tar xf ocserv-${OCSERV_VERSION}.tar.xz && \
     cd ocserv-${OCSERV_VERSION} && \
     ./configure --prefix=/opt/ocserv && \
     make -j"$(nproc)" && \
     make install
 
-FROM debian:bullseye-slim
+FROM base AS final
 
-ENV DEBIAN_FRONTEND=noninteractive
-
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    --mount=type=tmpfs,target=/var/log \
+    --mount=type=tmpfs,target=/var/tmp \
+    --mount=type=tmpfs,target=/var/cache/debconf \
+    --mount=type=tmpfs,target=/run \
+    --mount=type=tmpfs,target=/tmp \
+    set -x \
+ && apt-get update \
+ && apt-get upgrade -y -qq \
+ && apt-get install -y --no-install-recommends --no-install-suggests \
     libgnutls30 libev4 libpam0g libtalloc2 libradcli4 liboath0 \
     libprotobuf-c1 libgssapi-krb5-2 libk5crypto3 libkrb5-3 \
     libcom-err2 libkeyutils1 libidn2-0 libp11-kit0 libnettle8 \
-    libhogweed6 libgmp10 libtasn1-6 libffi7 libcap-ng0 libcrypt1 \
+    libhogweed6 libgmp10 libtasn1-6 libffi8 libcap-ng0 libcrypt1 \
     libunistring2 libaudit1 libreadline8 libnl-3-200 libnl-route-3-200 \
-    iproute2 iptables bash && \
-    rm -rf /var/lib/apt/lists/*
+    iproute2 iptables bash \
+ && apt purge --yes --auto-remove
 
-COPY --from=builder /opt/ocserv /opt/ocserv
 COPY entrypoint.sh /entrypoint.sh
-
-RUN chmod +x /entrypoint.sh
+COPY --link --from=builder /opt/ocserv /opt/ocserv
 
 WORKDIR /etc/ocserv
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+oci-image:
+	docker buildx build --progress=plain --pull -t ghcr.io/gifi71/ocserv-docker:latest .

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ docker run -d \
 
 - [x] Implement a multi-stage Docker build to reduce image size (`430MB` -> `113MB`)
 - [x] Publish image to GitHub Container Registry (`ghcr.io/gifi71/ocserv-docker`)
+- [x] Improve multi-stage Docker build to reduce image size (`113MB` -> `95MB`)
 
 ---
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 if [ -n "$PORTS" ]; then


### PR DESCRIPTION
subj
+check GPG sign of sources.