### PR TITLE
chore: ignore local scratch, tooling caches and upstream clone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,13 @@
 config/
 *.pem
 *.key
+
+# Local scratch / learning material (not part of the image)
+local/
+
+# Tooling caches
+.serena/
+.omc/
+
+# Upstream ocserv clone for tag diffing
+.upstream/


### PR DESCRIPTION
Adds `local/`, `.serena/`, `.omc/`, `.upstream/` to `.gitignore`.

- `local/` — learning material, not part of the image
- `.serena/`, `.omc/` — tooling caches
- `.upstream/` — ocserv clone used for tag diffing during the 1.5.0 bump