### PR TITLE
feat: bump ocserv to 1.5.0 and migrate build to meson

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG S6_OVERLAY_VERSION=3.2.2.0
-ARG OCSERV_VERSION=1.4.0
+ARG OCSERV_VERSION=1.5.0
 ARG OCSERV_EXPORTER_VERSION=0.2.2
 
 # ── Base image ────────────────────────────────────────────────────────────────
@@ -111,7 +111,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     libseccomp-dev libnl-route-3-dev libkrb5-dev libradcli-dev \
     libcurl4-gnutls-dev libcjose-dev libjansson-dev liboath-dev libssl-dev \
     libprotobuf-c-dev libtalloc-dev \
-    protobuf-c-compiler gperf ipcalc-ng gpg gpg-agent
+    protobuf-c-compiler gperf ipcalc-ng meson ninja-build gpg gpg-agent
 
 COPY ./keys/96865171.asc /usr/local/share/96865171.asc
 
@@ -131,9 +131,9 @@ RUN --mount=type=tmpfs,target=/tmp \
  && grep -q "^\[GNUPG:\] VALIDSIG 1F42418905D8206AA754CCDC29EE58B996865171" gpg-status.txt \
  && tar xf "ocserv-${OCSERV_VERSION}.tar.xz" \
  && cd "ocserv-${OCSERV_VERSION}" \
- && ./configure --prefix=/opt/ocserv --enable-oidc-auth \
- && make -j"$(nproc)" \
- && make install
+ && meson setup build --prefix=/opt/ocserv --buildtype=release -Doidc-auth=enabled \
+ && meson compile -C build \
+ && meson install -C build
 
 # ── Final image ───────────────────────────────────────────────────────────────
 FROM base AS final


### PR DESCRIPTION
Bumps ocserv 1.4.0 → **1.5.0** (cumulative over 1.4.1/1.4.2, includes their security fixes).

### Breaking upstream change
ocserv **1.4.2 replaced autotools with meson** (#699). The 1.5.0 release tarball ships only `meson.build` — no `configure` — so the old `./configure && make && make install` no longer works.

### Dockerfile changes (`ocserv-builder` stage)
- `ARG OCSERV_VERSION` 1.4.0 → 1.5.0
- add `meson` + `ninja-build` to build deps
- `./configure --enable-oidc-auth && make && make install` → `meson setup build --buildtype=release -Doidc-auth=enabled && meson compile -C build && meson install -C build`
- `oidc-auth` defaults to `disabled` in meson, so it is enabled explicitly to preserve OIDC support

### Verification (local)
- meson detects every dependency (gnutls 3.7.9, nettle 3.8.1, talloc, protobuf-c, pam, radcli, krb5-gssapi, liboath, libnl, lz4, seccomp, curl, cjose, jansson); `oidc-auth: enabled`
- GPG signature of the tarball valid against key `96865171` (unchanged)
- `ocserv --version` → `OpenConnect VPN Server 1.5.0` — seccomp, oath, radius, gssapi, PAM, PKCS#11, AnyConnect, oidc_auth
- integration suite **6/6 pass** (TLS, VPN tunnel, TUN iface, IP assignment, gateway ping, exporter metrics)

Feature set unchanged vs 1.4.0. No config-option migration needed (removed `cgroup` / renamed `min-reauth-time` are not used in our configs).