### PR TITLE
ci: auto-suppress unfixed CVEs, trim trivyignore to exporter Go CVEs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,10 @@ jobs:
           image-ref: ${{ needs.build.outputs.image }}@${{ needs.build.outputs.digest }}
           format: table
           severity: CRITICAL,HIGH
+          # Suppress CVEs with no upstream fix (Debian "will_not_fix"/"affected"/
+          # "fix_deferred"); only fixable-but-unpatched CVEs gate the build, plus
+          # whatever is explicitly listed in .trivyignore.
+          ignore-unfixed: true
           exit-code: '1'
           trivyignores: .trivyignore
 

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,20 +1,27 @@
-# TODO: remove when Debian releases a patched zlib1g package
-# Affects minizip's zipOpenNewFileInZip4_64, not used by ocserv
-CVE-2023-45853
+# OS-package CVEs that have no fix in Debian 12 are suppressed automatically via
+# `ignore-unfixed: true` in the Trivy scan step (.github/workflows/ci.yml); they
+# no longer need to be listed here individually.
+#
+# Listed below are CVEs that DO have an upstream fix but which we cannot pick up
+# yet, so they must be ignored explicitly (ignore-unfixed does not cover them).
 
-# TODO: remove when Debian releases a patched libldap package
-# Null pointer deref in OpenLDAP ber_memalloc_x, no fix in Debian 12
-CVE-2023-2953
-
-# TODO: remove when Debian releases a patched glibc package
-# glibc vulnerability, no fix in Debian 12
-CVE-2026-0861
-
-# TODO: remove when criteo/ocserv-exporter releases a build with Go >= 1.25.8
-# Go stdlib vulnerabilities bundled in pre-built exporter binary (Go 1.25.4)
-CVE-2025-68121
-CVE-2025-61730
-CVE-2025-61729
-CVE-2025-61728
+# ── ocserv-exporter (pre-built Go binary) ─────────────────────────────────────
+# criteo/ocserv-exporter v0.2.2 (latest release) ships a binary built with
+# Go 1.25.4, bundling Go stdlib vulnerabilities. No newer pre-built binary
+# exists. Remove these once the exporter is built from source with a patched Go.
+# Tracking: https://github.com/gifi71/ocserv-docker/issues/39
 CVE-2025-61726
+CVE-2025-61729
+CVE-2025-68121
 CVE-2026-25679
+CVE-2026-32280
+CVE-2026-32281
+CVE-2026-32283
+CVE-2026-33811
+CVE-2026-33814
+CVE-2026-39820
+CVE-2026-39823
+CVE-2026-39825
+CVE-2026-39836
+CVE-2026-42499
+CVE-2026-42504


### PR DESCRIPTION
Restores a green Trivy scan after the vuln DB picked up new 2026 CVEs in Debian-12 packages that have no upstream fix.

### Changes
- **`ignore-unfixed: true`** on the gating Trivy step — CVEs with no fix in Debian 12 (perl, ncurses, libssh2, libcurl, zlib, openldap, …) no longer break CI. The SARIF step keeps reporting everything for the Security tab.
- **`.trivyignore` trimmed** to only the criteo/ocserv-exporter Go stdlib CVEs. These *have* an upstream fix (newer Go) but ship in the pre-built v0.2.2 binary (Go 1.25.4), so `ignore-unfixed` does not cover them.
- Dropped: zlib/openldap/glibc entries (now covered by `ignore-unfixed`) and two stale Go CVEs that no longer fire (CVE-2025-61728, CVE-2025-61730).

### Why not Debian 13 (trixie)
Measured: `trixie-slim` (13.5, latest stable) still carries the 2 perl CRITICALs + ncurses CVE (all `fix_deferred` upstream) and adds 2 sqlite CVEs. No net benefit, plus migration risk. Staying on bookworm.

### Tracking
Exporter Go CVEs are tracked for a from-source rebuild in #39.

### Verified locally
`trivy --ignore-unfixed` with the new `.trivyignore` → **0 HIGH/CRITICAL** on the built 1.5.0 image (debian 0, gobinary 0).

> Stacked on #38; base retargets to `main` once that merges.