### PR TITLE
ci: ignore unfixed CVEs in scheduled scan to stop weekly noise issues

### DIFF
--- a/.github/workflows/scheduled-scan.yml
+++ b/.github/workflows/scheduled-scan.yml
@@ -43,6 +43,10 @@ jobs:
           format: table
           output: trivy-results.txt
           severity: CRITICAL
+          # Match the CI gate: only file an issue for CVEs that actually have a
+          # fix. Unfixed Debian-12 CVEs (e.g. perl-base CRITICALs) would
+          # otherwise re-open a noise issue every week.
+          ignore-unfixed: true
           exit-code: '1'
           trivyignores: .trivyignore
         continue-on-error: true


### PR DESCRIPTION
The weekly `scheduled-scan.yml` files a *Critical vulnerabilities found in latest image* issue every Monday for Debian-12 CVEs that have **no upstream fix** (e.g. `perl-base` CVE-2026-42496 / CVE-2026-8376). Issues #28–#35 are all instances of this.

Adds `ignore-unfixed: true` to the critical-check step so it matches the CI gate added in #41. Only fixable-but-unpatched CRITICALs now open an issue.

The SARIF upload step is left untouched, so the Security tab keeps full visibility.